### PR TITLE
Add settings & persistence for CatTracker

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,6 +25,7 @@
 
         <!-- 地图界面（仅内部跳转，无 filter 可省略 exported） -->
         <activity android:name=".map.MapActivity" />
+        <activity android:name=".SettingsActivity" />
 
         <!-- 启动入口 -->
         <activity

--- a/app/src/main/java/com/example/cattracker/AppPrefs.kt
+++ b/app/src/main/java/com/example/cattracker/AppPrefs.kt
@@ -1,0 +1,42 @@
+package com.example.cattracker
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.example.cattracker.data.CatReport
+import org.json.JSONArray
+
+object AppPrefs {
+    private const val PREFS_NAME = "cattracker_prefs"
+    private const val KEY_PORT = "server_port"
+    private const val KEY_REPORTS = "reports"
+
+    private lateinit var prefs: SharedPreferences
+
+    fun init(context: Context) {
+        prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    }
+
+    var port: Int
+        get() = prefs.getInt(KEY_PORT, 8080)
+        set(value) { prefs.edit().putInt(KEY_PORT, value).apply() }
+
+    fun loadReports(): List<CatReport> {
+        val json = prefs.getString(KEY_REPORTS, null) ?: return emptyList()
+        val arr = JSONArray(json)
+        val list = mutableListOf<CatReport>()
+        for (i in 0 until arr.length()) {
+            val obj = arr.getJSONObject(i)
+            list.add(CatReport.fromJson(obj))
+        }
+        return list
+    }
+
+    fun saveReports(reports: List<CatReport>) {
+        val arr = JSONArray()
+        for (r in reports) {
+            arr.put(r.toJson())
+        }
+        prefs.edit().putString(KEY_REPORTS, arr.toString()).apply()
+    }
+}
+

--- a/app/src/main/java/com/example/cattracker/SettingsActivity.kt
+++ b/app/src/main/java/com/example/cattracker/SettingsActivity.kt
@@ -1,0 +1,48 @@
+package com.example.cattracker
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.cattracker.ui.theme.CatTrackerTheme
+import com.example.cattracker.web.WebServerManager
+
+class SettingsActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            CatTrackerTheme {
+                SettingsScreen()
+            }
+        }
+    }
+}
+
+@Composable
+fun SettingsScreen() {
+    var portText by remember { mutableStateOf(AppPrefs.port.toString()) }
+
+    Column(modifier = Modifier.padding(16.dp)) {
+        OutlinedTextField(
+            value = portText,
+            onValueChange = { portText = it.filter { ch -> ch.isDigit() } },
+            label = { Text("Server Port") }
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Row {
+            Button(onClick = {
+                portText.toIntOrNull()?.let { port ->
+                    AppPrefs.port = port
+                    WebServerManager.start(port)
+                }
+            }) { Text("Start Server") }
+            Spacer(modifier = Modifier.width(8.dp))
+            Button(onClick = { WebServerManager.stop() }) { Text("Stop Server") }
+        }
+    }
+}
+

--- a/app/src/main/java/com/example/cattracker/data/ReportRepository.kt
+++ b/app/src/main/java/com/example/cattracker/data/ReportRepository.kt
@@ -1,13 +1,22 @@
 package com.example.cattracker.data
 
+import android.content.Context
+import com.example.cattracker.AppPrefs
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+
 
 object ReportRepository {
     private val _reports = MutableStateFlow<List<CatReport>>(emptyList())
     val reports = _reports.asStateFlow()
 
+    fun init(context: Context) {
+        AppPrefs.init(context)
+        _reports.value = AppPrefs.loadReports()
+    }
+
     fun addReport(report: CatReport) {
         _reports.value = _reports.value + report
+        AppPrefs.saveReports(_reports.value)
     }
 }

--- a/app/src/main/java/com/example/cattracker/web/CatWebServer.kt
+++ b/app/src/main/java/com/example/cattracker/web/CatWebServer.kt
@@ -6,11 +6,11 @@ import com.example.cattracker.data.ReportRepository
 import fi.iki.elonen.NanoHTTPD
 import org.json.JSONObject
 
-class CatWebServer : NanoHTTPD(8080) {
+class CatWebServer(port: Int) : NanoHTTPD(port) {
 
     fun startServer() {
         start(SOCKET_READ_TIMEOUT, false)
-        Log.i("CatWebServer", "Server started on port 8080")
+        Log.i("CatWebServer", "Server started on port $listeningPort")
     }
 
     override fun serve(session: IHTTPSession): Response {

--- a/app/src/main/java/com/example/cattracker/web/WebServerManager.kt
+++ b/app/src/main/java/com/example/cattracker/web/WebServerManager.kt
@@ -1,0 +1,16 @@
+package com.example.cattracker.web
+
+object WebServerManager {
+    private var server: CatWebServer? = null
+
+    fun start(port: Int) {
+        stop()
+        server = CatWebServer(port).also { it.startServer() }
+    }
+
+    fun stop() {
+        server?.stop()
+        server = null
+    }
+}
+


### PR DESCRIPTION
## Summary
- persist reports and port preferences with `AppPrefs`
- load saved reports on startup
- add a configurable `SettingsActivity`
- make `CatWebServer` accept a custom port
- expose global `WebServerManager`
- start server with saved port

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68611d173d308324ab39240c4ad23e7f