### PR TITLE
Observe reports and refresh map markers

### DIFF
--- a/app/src/main/java/com/example/cattracker/map/MapActivity.kt
+++ b/app/src/main/java/com/example/cattracker/map/MapActivity.kt
@@ -2,12 +2,16 @@ package com.example.cattracker.map
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.amap.api.maps.CameraUpdateFactory
 import com.amap.api.maps.MapView
 import com.amap.api.maps.model.LatLng
 import com.amap.api.maps.model.MarkerOptions
 import com.example.cattracker.R
 import com.example.cattracker.data.ReportRepository
+import kotlinx.coroutines.launch
 
 class MapActivity : AppCompatActivity() {
     private lateinit var mapView: MapView
@@ -17,17 +21,26 @@ class MapActivity : AppCompatActivity() {
         setContentView(R.layout.activity_map)
         mapView = findViewById(R.id.mapView)
         mapView.onCreate(savedInstanceState)
-        ReportRepository.reports.value.forEach { report ->
-            addMarker(report.lat, report.lng, report.catId)
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                ReportRepository.reports.collect { reports ->
+                    val map = mapView.map
+                    map.clear()
+                    reports.forEach { report ->
+                        val position = LatLng(report.lat, report.lng)
+                        map.addMarker(
+                            MarkerOptions().position(position).title(report.catId)
+                        )
+                    }
+                    reports.lastOrNull()?.let { last ->
+                        val lastPos = LatLng(last.lat, last.lng)
+                        map.moveCamera(CameraUpdateFactory.changeLatLng(lastPos))
+                    }
+                }
+            }
         }
     }
 
-    private fun addMarker(lat: Double, lng: Double, title: String) {
-        val map = mapView.map
-        val position = LatLng(lat, lng)
-        map.addMarker(MarkerOptions().position(position).title(title))
-        map.moveCamera(CameraUpdateFactory.changeLatLng(position))
-    }
 
     override fun onResume() {
         super.onResume()


### PR DESCRIPTION
## Summary
- observe `ReportRepository.reports` in `MapActivity`
- refresh markers whenever reports change and move camera to latest location

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861223b4a1083248e2de2428aada871