### PR TITLE
Fix permission duplication and map view layout

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,11 +14,6 @@
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
 
-    <!--允许访问网络，必选权限-->
-    <uses-permission android:name="android.permission.INTERNET" />
-
-    <!--允许获取粗略位置，若用GPS实现定位小蓝点功能则必选-->
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
     <!--允许获取网络状态，用于网络定位，若无gps但仍需实现定位小蓝点功能则此权限必选-->
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
@@ -29,8 +24,6 @@
     <!--允许获取wifi状态改变，用于网络定位，若无gps但仍需实现定位小蓝点功能则此权限必选-->
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
 
-    <!--允许写设备缓存，用于问题排查-->
-    <uses-permission android:name="android.permission.WRITE_SETTINGS" />
 
 
     <application

--- a/app/src/main/java/com/example/cattracker/MainActivity.kt
+++ b/app/src/main/java/com/example/cattracker/MainActivity.kt
@@ -17,6 +17,7 @@ import com.example.cattracker.ui.theme.CatTrackerTheme
 import com.example.cattracker.web.WebServerManager
 import com.example.cattracker.AppPrefs
 import com.example.cattracker.SettingsActivity
+import com.amap.api.maps.MapsInitializer
 
 class MainActivity : ComponentActivity() {
 
@@ -26,6 +27,9 @@ class MainActivity : ComponentActivity() {
         ReportRepository.init(applicationContext)
         // 启动服务器
         WebServerManager.start(AppPrefs.port)
+
+        MapsInitializer.updatePrivacyShow(applicationContext, true, true)
+        MapsInitializer.updatePrivacyAgree(applicationContext, true)
 
         setContent {
             CatTrackerTheme {

--- a/app/src/main/java/com/example/cattracker/ui/MapScreen.kt
+++ b/app/src/main/java/com/example/cattracker/ui/MapScreen.kt
@@ -5,6 +5,8 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.viewinterop.AndroidView
@@ -21,7 +23,7 @@ fun MapScreen(repo: ReportRepository) {
     val mapView = rememberMapViewWithLifecycle()
     val reports by repo.reports.collectAsState(initial = emptyList())
 
-    AndroidView(factory = { mapView }) { view ->
+    AndroidView(factory = { mapView }, modifier = Modifier.fillMaxSize()) { view ->
         val map = view.map
         map.clear()
         for (r in reports) {


### PR DESCRIPTION
## Summary
- fix duplicate permissions and remove unused permission in `AndroidManifest.xml`
- add AMap privacy updates in `MainActivity` initialization
- expand map view to fill screen in `MapScreen`

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68615a6d7ce883249f119a90f7316a43