### PR TITLE
Add Bluetooth controls and report list

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,6 +36,7 @@
             android:usesCleartextTraffic="true">   <!-- 如用 HTTPS 可删掉 -->
 
         <activity android:name=".SettingsActivity" />
+        <activity android:name=".ReportListActivity" />
 
         <!-- 启动入口 -->
         <activity

--- a/app/src/main/java/com/example/cattracker/AppPrefs.kt
+++ b/app/src/main/java/com/example/cattracker/AppPrefs.kt
@@ -9,6 +9,7 @@ object AppPrefs {
     private const val PREFS_NAME = "cattracker_prefs"
     private const val KEY_PORT = "server_port"
     private const val KEY_REPORTS = "reports"
+    private const val KEY_BLUETOOTH_ADDR = "bluetooth_addr"
 
     private lateinit var prefs: SharedPreferences
 
@@ -19,6 +20,10 @@ object AppPrefs {
     var port: Int
         get() = prefs.getInt(KEY_PORT, 8080)
         set(value) { prefs.edit().putInt(KEY_PORT, value).apply() }
+
+    var bluetoothAddress: String
+        get() = prefs.getString(KEY_BLUETOOTH_ADDR, "") ?: ""
+        set(value) { prefs.edit().putString(KEY_BLUETOOTH_ADDR, value).apply() }
 
     fun loadReports(): List<CatReport> {
         val json = prefs.getString(KEY_REPORTS, null) ?: return emptyList()

--- a/app/src/main/java/com/example/cattracker/MainActivity.kt
+++ b/app/src/main/java/com/example/cattracker/MainActivity.kt
@@ -1,6 +1,9 @@
 package com.example.cattracker
 
+import android.Manifest
 import android.os.Bundle
+import androidx.core.content.ContextCompat
+import androidx.core.app.ActivityCompat
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.padding
@@ -17,12 +20,25 @@ import com.example.cattracker.ui.theme.CatTrackerTheme
 import com.example.cattracker.web.WebServerManager
 import com.example.cattracker.AppPrefs
 import com.example.cattracker.SettingsActivity
+import com.example.cattracker.ReportListActivity
 import com.amap.api.maps.MapsInitializer
 
 class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        if (ContextCompat.checkSelfPermission(
+                this,
+                Manifest.permission.ACCESS_FINE_LOCATION
+            ) != android.content.pm.PackageManager.PERMISSION_GRANTED
+        ) {
+            ActivityCompat.requestPermissions(
+                this,
+                arrayOf(Manifest.permission.ACCESS_FINE_LOCATION),
+                0
+            )
+        }
 
         ReportRepository.init(applicationContext)
         // 启动服务器
@@ -60,6 +76,11 @@ fun AppContent(repo: ReportRepository) {
                         context.startActivity(Intent(context, SettingsActivity::class.java))
                     }) {
                         Text("Settings", color = MaterialTheme.colors.onPrimary)
+                    }
+                    TextButton(onClick = {
+                        context.startActivity(Intent(context, ReportListActivity::class.java))
+                    }) {
+                        Text("Reports", color = MaterialTheme.colors.onPrimary)
                     }
                 }
             )

--- a/app/src/main/java/com/example/cattracker/ReportListActivity.kt
+++ b/app/src/main/java/com/example/cattracker/ReportListActivity.kt
@@ -1,0 +1,19 @@
+package com.example.cattracker
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import com.example.cattracker.data.ReportRepository
+import com.example.cattracker.ui.ReportListScreen
+import com.example.cattracker.ui.theme.CatTrackerTheme
+
+class ReportListActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            CatTrackerTheme {
+                ReportListScreen(ReportRepository)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/cattracker/SettingsActivity.kt
+++ b/app/src/main/java/com/example/cattracker/SettingsActivity.kt
@@ -1,15 +1,22 @@
 package com.example.cattracker
 
+import android.Manifest
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
 import com.example.cattracker.ui.theme.CatTrackerTheme
 import com.example.cattracker.web.WebServerManager
+import com.example.cattracker.bluetooth.BluetoothService
 
 class SettingsActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -25,12 +32,31 @@ class SettingsActivity : ComponentActivity() {
 @Composable
 fun SettingsScreen() {
     var portText by remember { mutableStateOf(AppPrefs.port.toString()) }
+    var addressText by remember { mutableStateOf(AppPrefs.bluetoothAddress) }
+    val context = LocalContext.current
+
+    val btPermissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        if (granted || Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            BluetoothService(AppPrefs.bluetoothAddress).connect()
+        }
+    }
 
     Column(modifier = Modifier.padding(16.dp)) {
         OutlinedTextField(
             value = portText,
             onValueChange = { portText = it.filter { ch -> ch.isDigit() } },
             label = { Text("Server Port") }
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        OutlinedTextField(
+            value = addressText,
+            onValueChange = {
+                addressText = it
+                AppPrefs.bluetoothAddress = it
+            },
+            label = { Text("Bluetooth MAC Address") }
         )
         Spacer(modifier = Modifier.height(16.dp))
         Row {
@@ -42,6 +68,22 @@ fun SettingsScreen() {
             }) { Text("Start Server") }
             Spacer(modifier = Modifier.width(8.dp))
             Button(onClick = { WebServerManager.stop() }) { Text("Stop Server") }
+            Spacer(modifier = Modifier.width(8.dp))
+            Button(onClick = {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    if (ContextCompat.checkSelfPermission(
+                            context,
+                            Manifest.permission.BLUETOOTH_CONNECT
+                        ) == android.content.pm.PackageManager.PERMISSION_GRANTED
+                    ) {
+                        BluetoothService(AppPrefs.bluetoothAddress).connect()
+                    } else {
+                        btPermissionLauncher.launch(Manifest.permission.BLUETOOTH_CONNECT)
+                    }
+                } else {
+                    BluetoothService(AppPrefs.bluetoothAddress).connect()
+                }
+            }) { Text("Connect BT") }
         }
     }
 }

--- a/app/src/main/java/com/example/cattracker/ui/MapScreen.kt
+++ b/app/src/main/java/com/example/cattracker/ui/MapScreen.kt
@@ -25,6 +25,8 @@ fun MapScreen(repo: ReportRepository) {
 
     AndroidView(factory = { mapView }, modifier = Modifier.fillMaxSize()) { view ->
         val map = view.map
+        map.uiSettings.isMyLocationButtonEnabled = true
+        map.isMyLocationEnabled = true
         map.clear()
         for (r in reports) {
             val pos = LatLng(r.lat, r.lng)

--- a/app/src/main/java/com/example/cattracker/ui/ReportListScreen.kt
+++ b/app/src/main/java/com/example/cattracker/ui/ReportListScreen.kt
@@ -1,0 +1,31 @@
+package com.example.cattracker.ui
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import com.example.cattracker.data.ReportRepository
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+@Composable
+fun ReportListScreen(repo: ReportRepository) {
+    val reports by repo.reports.collectAsState(initial = emptyList())
+    val sorted = reports.sortedBy { it.timestamp }
+    LazyColumn {
+        items(sorted) { r ->
+            val time = dateFormat.format(Date(r.timestamp))
+            Text(
+                text = "${r.catId} - $time (${r.lat}, ${r.lng})",
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+    }
+}
+
+private val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())


### PR DESCRIPTION
## Summary
- store Bluetooth address in `AppPrefs`
- extend Settings screen with Bluetooth address field and connect button
- enable my-location layer on map
- request location permission at startup
- provide a report list screen and add menu entry
- register `ReportListActivity` in manifest

## Testing
- `./gradlew assembleDebug` *(fails: SDK not found)*

------
https://chatgpt.com/codex/tasks/task_e_68615e25a2a48324b48e0041110be686