### PR TITLE
Improve map display and port validation

### DIFF
--- a/app/src/main/java/com/example/cattracker/SettingsActivity.kt
+++ b/app/src/main/java/com/example/cattracker/SettingsActivity.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
+import android.widget.Toast
 import com.example.cattracker.ui.theme.CatTrackerTheme
 import com.example.cattracker.web.WebServerManager
 import com.example.cattracker.bluetooth.BluetoothService
@@ -32,6 +33,7 @@ class SettingsActivity : ComponentActivity() {
 @Composable
 fun SettingsScreen() {
     var portText by remember { mutableStateOf(AppPrefs.port.toString()) }
+    var isPortError by remember { mutableStateOf(false) }
     var addressText by remember { mutableStateOf(AppPrefs.bluetoothAddress) }
     val context = LocalContext.current
 
@@ -46,8 +48,12 @@ fun SettingsScreen() {
     Column(modifier = Modifier.padding(16.dp)) {
         OutlinedTextField(
             value = portText,
-            onValueChange = { portText = it.filter { ch -> ch.isDigit() } },
-            label = { Text("Server Port") }
+            onValueChange = {
+                portText = it.filter { ch -> ch.isDigit() }
+                isPortError = portText.toIntOrNull() == null
+            },
+            label = { Text("Server Port") },
+            isError = isPortError
         )
         Spacer(modifier = Modifier.height(16.dp))
         OutlinedTextField(
@@ -61,9 +67,14 @@ fun SettingsScreen() {
         Spacer(modifier = Modifier.height(16.dp))
         Row {
             Button(onClick = {
-                portText.toIntOrNull()?.let { port ->
+                val port = portText.toIntOrNull()
+                if (port != null) {
+                    isPortError = false
                     AppPrefs.port = port
                     WebServerManager.start(port)
+                } else {
+                    isPortError = true
+                    Toast.makeText(context, "Invalid server port", Toast.LENGTH_SHORT).show()
                 }
             }) { Text("Start Server") }
             Spacer(modifier = Modifier.width(8.dp))

--- a/app/src/main/java/com/example/cattracker/map/MapActivity.kt
+++ b/app/src/main/java/com/example/cattracker/map/MapActivity.kt
@@ -9,6 +9,7 @@ import com.amap.api.maps.CameraUpdateFactory
 import com.amap.api.maps.MapView
 import com.amap.api.maps.model.LatLng
 import com.amap.api.maps.model.MarkerOptions
+import com.amap.api.maps.model.PolylineOptions
 import com.example.cattracker.R
 import com.example.cattracker.data.ReportRepository
 import kotlinx.coroutines.launch
@@ -26,13 +27,19 @@ class MapActivity : AppCompatActivity() {
                 ReportRepository.reports.collect { reports ->
                     val map = mapView.map
                     map.clear()
-                    reports.forEach { report ->
+                    val sorted = reports.sortedBy { it.timestamp }
+                    val polyline = PolylineOptions()
+                    sorted.forEach { report ->
                         val position = LatLng(report.lat, report.lng)
-                        map.addMarker(
-                            MarkerOptions().position(position).title(report.catId)
-                        )
+                        polyline.add(position)
+                        val marker = MarkerOptions().position(position).title(report.catId)
+                        report.info?.let { marker.snippet(it) }
+                        map.addMarker(marker)
                     }
-                    reports.lastOrNull()?.let { last ->
+                    if (polyline.points.size > 1) {
+                        map.addPolyline(polyline)
+                    }
+                    sorted.lastOrNull()?.let { last ->
                         val lastPos = LatLng(last.lat, last.lng)
                         map.moveCamera(CameraUpdateFactory.changeLatLng(lastPos))
                     }

--- a/app/src/main/java/com/example/cattracker/ui/MapScreen.kt
+++ b/app/src/main/java/com/example/cattracker/ui/MapScreen.kt
@@ -16,6 +16,7 @@ import com.amap.api.maps.CameraUpdateFactory
 import com.amap.api.maps.MapView
 import com.amap.api.maps.model.LatLng
 import com.amap.api.maps.model.MarkerOptions
+import com.amap.api.maps.model.PolylineOptions
 import com.example.cattracker.data.ReportRepository
 
 @Composable
@@ -28,12 +29,20 @@ fun MapScreen(repo: ReportRepository) {
         map.uiSettings.isMyLocationButtonEnabled = true
         map.isMyLocationEnabled = true
         map.clear()
-        for (r in reports) {
+        val sortedReports = reports.sortedBy { it.timestamp }
+        val polyline = PolylineOptions()
+        for (r in sortedReports) {
             val pos = LatLng(r.lat, r.lng)
-            map.addMarker(MarkerOptions().position(pos).title(r.catId))
+            polyline.add(pos)
+            val marker = MarkerOptions().position(pos).title(r.catId)
+            r.info?.let { marker.snippet(it) }
+            map.addMarker(marker)
         }
-        if (reports.isNotEmpty()) {
-            val last = reports.last()
+        if (polyline.points.size > 1) {
+            map.addPolyline(polyline)
+        }
+        if (sortedReports.isNotEmpty()) {
+            val last = sortedReports.last()
             map.moveCamera(
                 CameraUpdateFactory.changeLatLng(LatLng(last.lat, last.lng))
             )

--- a/app/src/main/java/com/example/cattracker/ui/ReportListScreen.kt
+++ b/app/src/main/java/com/example/cattracker/ui/ReportListScreen.kt
@@ -1,6 +1,6 @@
 package com.example.cattracker.ui
 
-import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.Text
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
 import com.example.cattracker.data.ReportRepository
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -17,13 +18,19 @@ import java.util.Locale
 fun ReportListScreen(repo: ReportRepository) {
     val reports by repo.reports.collectAsState(initial = emptyList())
     val sorted = reports.sortedBy { it.timestamp }
-    LazyColumn {
-        items(sorted) { r ->
-            val time = dateFormat.format(Date(r.timestamp))
-            Text(
-                text = "${r.catId} - $time (${r.lat}, ${r.lng})",
-                modifier = Modifier.fillMaxWidth()
-            )
+    if (sorted.isEmpty()) {
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Text("No cat reports yet.")
+        }
+    } else {
+        LazyColumn {
+            items(sorted) { r ->
+                val time = dateFormat.format(Date(r.timestamp))
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    Text(text = "${r.catId} - $time (${r.lat}, ${r.lng})")
+                    r.info?.let { Text(it) }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- validate server port entry in `SettingsActivity` and show a toast when invalid
- show `info` field and empty state message in `ReportListScreen`
- include `info` snippets and a polyline on maps

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686206e76144832498fffe1fa4ba3ee0