### PR TITLE
Improve MapScreen zoom and filtering

### DIFF
--- a/app/src/main/java/com/example/cattracker/MainActivity.kt
+++ b/app/src/main/java/com/example/cattracker/MainActivity.kt
@@ -55,8 +55,10 @@ class MainActivity : ComponentActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
-        // 关闭服务器，释放端口
+        // Stop the embedded HTTP server and close the repository's coroutine
+        // scope to avoid leaking background work
         WebServerManager.stop()
+        ReportRepository.close()
     }
 }
 

--- a/app/src/main/java/com/example/cattracker/data/ReportRepository.kt
+++ b/app/src/main/java/com/example/cattracker/data/ReportRepository.kt
@@ -2,13 +2,19 @@ package com.example.cattracker.data
 
 import android.content.Context
 import com.example.cattracker.AppPrefs
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 
 
 object ReportRepository {
     private val _reports = MutableStateFlow<List<CatReport>>(emptyList())
     val reports = _reports.asStateFlow()
+    private val ioScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     fun init(context: Context) {
         AppPrefs.init(context)
@@ -17,6 +23,14 @@ object ReportRepository {
 
     fun addReport(report: CatReport) {
         _reports.value = _reports.value + report
-        AppPrefs.saveReports(_reports.value)
+        ioScope.launch { AppPrefs.saveReports(_reports.value) }
+    }
+
+    /**
+     * Cancel the background coroutine scope used for saving reports.
+     * Call from the app's cleanup logic to avoid leaking coroutines.
+     */
+    fun close() {
+        ioScope.cancel()
     }
 }

--- a/app/src/main/java/com/example/cattracker/ui/MapScreen.kt
+++ b/app/src/main/java/com/example/cattracker/ui/MapScreen.kt
@@ -1,51 +1,137 @@
 package com.example.cattracker.ui
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.collectAsState
+import android.app.DatePickerDialog
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.FloatingActionButton
+import androidx.compose.material.Icon
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material.icons.filled.ZoomIn
+import androidx.compose.material.icons.filled.ZoomOut
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.amap.api.maps.CameraUpdateFactory
 import com.amap.api.maps.MapView
 import com.amap.api.maps.model.LatLng
+import com.amap.api.maps.model.Marker
 import com.amap.api.maps.model.MarkerOptions
+import com.amap.api.maps.model.Polyline
 import com.amap.api.maps.model.PolylineOptions
 import com.example.cattracker.data.ReportRepository
+import java.util.Calendar
 
 @Composable
 fun MapScreen(repo: ReportRepository) {
     val mapView = rememberMapViewWithLifecycle()
+    // Map object must be re-acquired if the MapView instance changes
+    val map = remember(mapView) { mapView.map }
     val reports by repo.reports.collectAsState(initial = emptyList())
+    var selectedDate by remember { mutableStateOf<Long?>(null) }
+    var showDatePicker by remember { mutableStateOf(false) }
+    val context = LocalContext.current
+    val markers = remember { mutableMapOf<String, Marker>() }
+    var polyline by remember { mutableStateOf<Polyline?>(null) }
 
-    AndroidView(factory = { mapView }, modifier = Modifier.fillMaxSize()) { view ->
-        val map = view.map
+    if (showDatePicker) {
+        LaunchedEffect(Unit) {
+            val cal = Calendar.getInstance()
+            DatePickerDialog(
+                context,
+                { _, y, m, d ->
+                    val sel = Calendar.getInstance().apply {
+                        set(y, m, d, 0, 0, 0)
+                        set(Calendar.MILLISECOND, 0)
+                    }
+                    selectedDate = sel.timeInMillis
+                    showDatePicker = false
+                },
+                cal.get(Calendar.YEAR),
+                cal.get(Calendar.MONTH),
+                cal.get(Calendar.DAY_OF_MONTH)
+            ).apply {
+                // Hide the picker when the user cancels without selecting a date
+                setOnCancelListener { showDatePicker = false }
+            }.show()
+        }
+    }
+
+    LaunchedEffect(map) {
         map.uiSettings.isMyLocationButtonEnabled = true
+        map.uiSettings.isZoomControlsEnabled = true
         map.isMyLocationEnabled = true
-        map.clear()
-        val sortedReports = reports.sortedBy { it.timestamp }
-        val polyline = PolylineOptions()
+    }
+
+    LaunchedEffect(reports, selectedDate) {
+        val filtered = selectedDate?.let { date ->
+            val end = date + 24 * 60 * 60 * 1000
+            reports.filter { it.timestamp in date until end }
+        } ?: reports
+
+        val ids = filtered.map { "${'$'}{it.catId}_${'$'}{it.timestamp}" }.toSet()
+        val removeIds = markers.keys - ids
+        removeIds.forEach { id ->
+            markers.remove(id)?.remove()
+        }
+
+        val sortedReports = filtered.sortedBy { it.timestamp }
         for (r in sortedReports) {
+            val id = "${'$'}{r.catId}_${'$'}{r.timestamp}"
             val pos = LatLng(r.lat, r.lng)
-            polyline.add(pos)
-            val marker = MarkerOptions().position(pos).title(r.catId)
-            r.info?.let { marker.snippet(it) }
-            map.addMarker(marker)
+            val m = markers[id]
+            if (m == null) {
+                val opts = MarkerOptions().position(pos).title(r.catId)
+                r.info?.let { opts.snippet(it) }
+                markers[id] = map.addMarker(opts)
+            } else {
+                m.position = pos
+                m.title = r.catId
+                m.snippet = r.info
+            }
         }
-        if (polyline.points.size > 1) {
-            map.addPolyline(polyline)
+
+        val points = sortedReports.map { LatLng(it.lat, it.lng) }
+        if (points.size > 1) {
+            if (polyline == null) {
+                polyline = map.addPolyline(PolylineOptions().addAll(points))
+            } else {
+                polyline!!.points = points
+            }
+        } else {
+            polyline?.remove()
+            polyline = null
         }
-        if (sortedReports.isNotEmpty()) {
-            val last = sortedReports.last()
+
+        sortedReports.lastOrNull()?.let { last ->
             map.moveCamera(
                 CameraUpdateFactory.changeLatLng(LatLng(last.lat, last.lng))
             )
+        }
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        AndroidView(factory = { mapView }, modifier = Modifier.fillMaxSize())
+        Column(
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            FloatingActionButton(onClick = {
+                map.animateCamera(CameraUpdateFactory.zoomIn())
+            }) { Icon(Icons.Default.ZoomIn, contentDescription = null) }
+            FloatingActionButton(onClick = {
+                map.animateCamera(CameraUpdateFactory.zoomOut())
+            }) { Icon(Icons.Default.ZoomOut, contentDescription = null) }
+            FloatingActionButton(onClick = { showDatePicker = true }) {
+                Icon(Icons.Default.DateRange, contentDescription = null)
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add IO coroutine scope for saving reports
- enhance map screen with zoom buttons, date filtering, and incremental marker updates
- acquire map instance with `remember(mapView)` and handle date picker cancellation
- **new**: clean up `ReportRepository` in `onDestroy`

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68637d1cd7dc8324aa0231b6e0096690