### PR TITLE
Fix map recentering and improve report list

### DIFF
--- a/app/src/main/java/com/example/cattracker/MainActivity.kt
+++ b/app/src/main/java/com/example/cattracker/MainActivity.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import android.content.Intent
+import androidx.compose.material.IconButton
 import androidx.compose.material.TextButton
 import androidx.compose.ui.res.stringResource
 import androidx.compose.runtime.LaunchedEffect
@@ -33,6 +34,9 @@ import com.example.cattracker.SettingsActivity
 import com.example.cattracker.ReportListActivity
 import com.example.cattracker.R
 import com.amap.api.maps.MapsInitializer
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.List
 
 class MainActivity : ComponentActivity() {
 
@@ -110,15 +114,23 @@ fun AppContent(repo: ReportRepository) {
             TopAppBar(
                 title = { Text(stringResource(R.string.title_main)) },
                 actions = {
-                    TextButton(onClick = {
+                    IconButton(onClick = {
                         context.startActivity(Intent(context, SettingsActivity::class.java))
                     }) {
-                        Text(stringResource(R.string.btn_settings), color = MaterialTheme.colors.onPrimary)
+                        Icon(
+                            imageVector = Icons.Default.Settings,
+                            contentDescription = stringResource(R.string.btn_settings),
+                            tint = MaterialTheme.colors.onPrimary
+                        )
                     }
-                    TextButton(onClick = {
+                    IconButton(onClick = {
                         context.startActivity(Intent(context, ReportListActivity::class.java))
                     }) {
-                        Text(stringResource(R.string.btn_reports), color = MaterialTheme.colors.onPrimary)
+                        Icon(
+                            imageVector = Icons.Default.List,
+                            contentDescription = stringResource(R.string.btn_reports),
+                            tint = MaterialTheme.colors.onPrimary
+                        )
                     }
                 }
             )

--- a/app/src/main/java/com/example/cattracker/ui/MapScreen.kt
+++ b/app/src/main/java/com/example/cattracker/ui/MapScreen.kt
@@ -23,6 +23,7 @@ import com.amap.api.maps.model.Marker
 import com.amap.api.maps.model.MarkerOptions
 import com.amap.api.maps.model.Polyline
 import com.amap.api.maps.model.PolylineOptions
+import com.amap.api.maps.model.MyLocationStyle
 import com.example.cattracker.R
 import com.example.cattracker.data.ReportRepository
 import java.util.Calendar
@@ -66,6 +67,10 @@ fun MapScreen(repo: ReportRepository) {
         map.uiSettings.isMyLocationButtonEnabled = true
         map.uiSettings.isZoomControlsEnabled = true
         map.isMyLocationEnabled = true
+        val locStyle = MyLocationStyle().apply {
+            myLocationType(MyLocationStyle.LOCATION_TYPE_SHOW)
+        }
+        map.myLocationStyle = locStyle
     }
 
     LaunchedEffect(reports, selectedDate) {

--- a/app/src/main/java/com/example/cattracker/ui/ReportListScreen.kt
+++ b/app/src/main/java/com/example/cattracker/ui/ReportListScreen.kt
@@ -4,12 +4,15 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.Text
+import androidx.compose.material.Card
+import androidx.compose.material.Divider
 import androidx.compose.ui.res.stringResource
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.unit.dp
 import com.example.cattracker.R
 import com.example.cattracker.data.ReportRepository
 import java.text.SimpleDateFormat
@@ -19,7 +22,7 @@ import java.util.Locale
 @Composable
 fun ReportListScreen(repo: ReportRepository) {
     val reports by repo.reports.collectAsState(initial = emptyList())
-    val sorted = reports.sortedBy { it.timestamp }
+    val sorted = reports.sortedByDescending { it.timestamp }
     if (sorted.isEmpty()) {
         Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
             Text(stringResource(R.string.msg_no_reports))
@@ -28,10 +31,17 @@ fun ReportListScreen(repo: ReportRepository) {
         LazyColumn {
             items(sorted) { r ->
                 val time = dateFormat.format(Date(r.timestamp))
-                Column(modifier = Modifier.fillMaxWidth()) {
-                    Text(text = "${r.catId} - $time (${r.lat}, ${r.lng})")
-                    r.info?.let { Text(it) }
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(8.dp)
+                ) {
+                    Column(modifier = Modifier.padding(8.dp)) {
+                        Text(text = "${r.catId} - $time (${r.lat}, ${r.lng})")
+                        r.info?.let { Text(it) }
+                    }
                 }
+                Divider()
             }
         }
     }


### PR DESCRIPTION
## Summary
- disable automatic map recentering with `MyLocationStyle`
- show reports newest first
- use cards with dividers in the report list
- beautify the main menu using icons

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864cdaba83083249e6734ef907b9554